### PR TITLE
Agrega comando seed_db para poblar la base de datos de forma automática

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 django = "*"
 psycopg2-binary = "*"
 djangorestframework-api-key = "*"
+factory-boy = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "605b352d562720e4d396d7438adec3dffd049705ef6a77fa66f759ca8e0bfc64"
+            "sha256": "bd4968cd629d5d5822fcac398b150824ab44476e3e147981ed79364e7d5c990e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -40,6 +40,22 @@
             "index": "pypi",
             "version": "==2.0.0"
         },
+        "factory-boy": {
+            "hashes": [
+                "sha256:728df59b372c9588b83153facf26d3d28947fc750e8e3c95cefa9bed0e6394ee",
+                "sha256:faf48d608a1735f0d0a3c9cbf536d64f9132b547dae7ba452c4d99a79e84a370"
+            ],
+            "index": "pypi",
+            "version": "==2.12.0"
+        },
+        "faker": {
+            "hashes": [
+                "sha256:1290f589648bc470b8d98fff1fdff773fe3f46b4ca2cac73ac74668b12cf008e",
+                "sha256:c006b3664c270a2cfd4785c5e41ff263d48101c4e920b5961cf9c237131d8418"
+            ],
+            "markers": "python_version >= '3.4'",
+            "version": "==4.1.1"
+        },
         "psycopg2-binary": {
             "hashes": [
                 "sha256:008da3ab51adc70a5f1cfbbe5db3a22607ab030eb44bcecf517ad11a0c2b3cac",
@@ -76,12 +92,28 @@
             "index": "pypi",
             "version": "==2.8.5"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.1"
+        },
         "pytz": {
             "hashes": [
                 "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
                 "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
             ],
             "version": "==2020.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
         },
         "sqlparse": {
             "hashes": [
@@ -90,6 +122,13 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.3.1"
+        },
+        "text-unidecode": {
+            "hashes": [
+                "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8",
+                "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"
+            ],
+            "version": "==1.3"
         }
     },
     "develop": {}

--- a/restaurants/factory_data.py
+++ b/restaurants/factory_data.py
@@ -1,0 +1,32 @@
+import factory
+from factory.django import DjangoModelFactory
+import random
+from decimal import Decimal
+
+from .models import Restaurant, Product
+
+
+class RestaurantFactory(DjangoModelFactory):
+    ''' Esta clase se define para crear objetos Restaurant implementando la librería Faker    
+    y así poblar la base de datos para realizar pruebas funcionales
+    '''
+
+    class Meta:
+        model = Restaurant
+
+    name = factory.Faker('name')
+    city = factory.Faker('city')
+    address = factory.Faker('address')
+
+
+class ProductFactory(DjangoModelFactory):
+    ''' Esta clase se define para crear objetos Restaurant implementando la librería Faker    
+    y así poblar la base de datos para realizar pruebas funcionales
+    '''
+
+    class Meta:
+        model = Product
+
+    name = factory.Faker('sentence')
+    description = factory.Faker('text')
+    price = float(Decimal(random.randrange(3500, 135000)))

--- a/restaurants/management/commands/seed_db.py
+++ b/restaurants/management/commands/seed_db.py
@@ -1,0 +1,37 @@
+from django.core.management.base import BaseCommand
+
+from restaurants.factory_data import RestaurantFactory, ProductFactory
+
+
+class Command(BaseCommand):
+    help = 'Populate database for API testing'
+
+    def add_arguments(self, parser):
+        ''' Fuunción que define los argumentos de entrada que se pueden
+        pasar en la ejecución del comando
+        '''
+        parser.add_argument(
+            '--restaurants',
+            default=50,
+            type=int,
+            help='Number of restaurants to create (default 50)'
+        )
+
+        parser.add_argument(
+            '--products',
+            default=50,
+            type=int,
+            help='Number of products to create for each restaurant (default 50)'
+        )
+
+    def handle(self, *args, **options):
+        ''' Crea n restaurantes y n productos definidos por el usuario y
+        los almacena en la base de datos
+        '''
+
+        for i in range(options['restaurants']):
+            restaurant = (RestaurantFactory.create())
+            for j in range(options['products']):
+                ProductFactory.create(restaurant=restaurant)
+                
+            print('> ' + str(i + 1) + ' ceated restaurants')


### PR DESCRIPTION
El comando `python manage.py seed_db` permite poblar de forma automática la base datos con objetos `Restaurant` y `Products`
Este comando recibe dos parámetros opcionales:
* `--restaurants`: Número entero que define la cantidad de restaurantes que se desea crear
* `--products`: Número entero que define la cantidad de productos a crear por cada restaurante
